### PR TITLE
MovieCard 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "netflix-demo",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-brands-svg-icons": "^6.6.0",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@tanstack/react-query": "^5.53.3",
         "@tanstack/react-query-devtools": "^5.54.0",
         "@testing-library/jest-dom": "^5.17.0",
@@ -18,6 +22,7 @@
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.4",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-multi-carousel": "^2.8.5",
         "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
@@ -2378,6 +2383,59 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
+      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-1MPD8lMNW/earme4OQi1IFHtmHUwAKgghXlNwWi9GO7QkTfD+IIaYpIai4m2YJEzqfEji3jFHX1DZI5pbY/biQ==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -15205,6 +15263,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.6.0",
+    "@fortawesome/free-brands-svg-icons": "^6.6.0",
+    "@fortawesome/free-regular-svg-icons": "^6.6.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@tanstack/react-query": "^5.53.3",
     "@tanstack/react-query-devtools": "^5.54.0",
     "@testing-library/jest-dom": "^5.17.0",
@@ -13,6 +17,7 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.4",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-multi-carousel": "^2.8.5",
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",

--- a/src/App.css
+++ b/src/App.css
@@ -2,10 +2,10 @@ body,
 html,
 #root,
 .App {
-  width: 100%;
+  /* width: 100%;
   height: 100%;
   margin: 0;
-  padding: 0;
+  padding: 0; */
   background-color: black;
   color: white !important;
 }

--- a/src/pages/Homepage/components/MovieCard/MovieCard.jsx
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import Badge from 'react-bootstrap/Badge';
 import './MovieCard.style.css';
+import { FaUser } from 'react-icons/fa';
+import { FaFireAlt } from 'react-icons/fa';
+import { MdNoAdultContent } from 'react-icons/md';
 
 const MovieCard = ({ movie }) => {
   console.log('moviecard', movie);
@@ -15,14 +18,27 @@ const MovieCard = ({ movie }) => {
       className='movie-card'
     >
       <div className='overlay'>
-        <h1>{movie.title}</h1>
-        {movie.genre_ids.map((id) => (
-          <Badge bg='warning'>{id}</Badge>
-        ))}
-        <div>
-          <div>{movie.vote_average}</div>
-          <div>{movie.popularity}</div>
-          <div>{movie.adult ? 'over18' : 'under18'}</div>
+        <div className='overlay-title'>
+          <h1>{movie.title}</h1>
+        </div>
+        <div className='overlay-content'>
+          <div className='overlay-badge'>
+            {movie.genre_ids.map((id) => (
+              <Badge bg='warning'>{id}</Badge>
+            ))}
+          </div>
+
+          <div className='overlay-info'>
+            <div className='overlay-icon'>
+              <FaUser />
+              {movie.vote_average}
+            </div>
+            <div className='overlay-icon'>
+              <FaFireAlt />
+              {movie.popularity}
+            </div>
+            <div>{movie.adult ? <MdNoAdultContent /> : ''}</div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/Homepage/components/MovieCard/MovieCard.jsx
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.jsx
@@ -1,7 +1,30 @@
 import React from 'react';
+import Badge from 'react-bootstrap/Badge';
 
-const MovieCard = () => {
-  return <div>MovieCard</div>;
+const MovieCard = ({ movie }) => {
+  console.log('moviecard', movie);
+  return (
+    <div
+      style={{
+        backgroundImage:
+          'url(' +
+          `https://media.themoviedb.org/t/p/w440_and_h660_face${movie.poster_path}` +
+          ')',
+      }}
+    >
+      <div>
+        <h1>{movie.title}</h1>
+        {movie.genre_ids.map((id) => (
+          <Badge bg='warning'>{id}</Badge>
+        ))}
+        <div>
+          <div>{movie.vote_average}</div>
+          <div>{movie.popularity}</div>
+          <div>{movie.adult ? 'over18' : 'under18'}</div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default MovieCard;

--- a/src/pages/Homepage/components/MovieCard/MovieCard.jsx
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Badge from 'react-bootstrap/Badge';
+import './MovieCard.style.css';
 
 const MovieCard = ({ movie }) => {
   console.log('moviecard', movie);
@@ -11,8 +12,9 @@ const MovieCard = ({ movie }) => {
           `https://media.themoviedb.org/t/p/w440_and_h660_face${movie.poster_path}` +
           ')',
       }}
+      className='movie-card'
     >
-      <div>
+      <div className='overlay'>
         <h1>{movie.title}</h1>
         {movie.genre_ids.map((id) => (
           <Badge bg='warning'>{id}</Badge>

--- a/src/pages/Homepage/components/MovieCard/MovieCard.style.css
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.style.css
@@ -1,0 +1,27 @@
+.movie-card {
+  width: 220px;
+  height: 330px;
+  background-size: cover;
+  cursor: pointer;
+  transition: 0.5s;
+}
+
+.overlay {
+  width: 100%;
+  height: 100%;
+  background: rgba(43, 41, 41, 0.9);
+  opacity: 0;
+  transition: all 1s;
+  color: white;
+  font-weight: bold;
+  overflow-wrap: break-word;
+}
+
+.overlay:hover {
+  opacity: 1;
+}
+
+.movie-card:hover {
+  transform: scale(1.3) translateZ(20px);
+  z-index: 2;
+}

--- a/src/pages/Homepage/components/MovieCard/MovieCard.style.css
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.style.css
@@ -15,6 +15,10 @@
   color: white;
   font-weight: bold;
   overflow-wrap: break-word;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .overlay:hover {
@@ -25,4 +29,35 @@
   transform: scale(1.3) translateZ(20px);
   z-index: 2; /* 다른 카드 위로 올라오도록 설정 */
   position: relative; /* 부모와의 관계에서 z-index가 작동하도록 설정 */
+}
+
+.overlay-title > h1 {
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overlay-badge {
+  display: flex;
+  gap: 5px;
+}
+
+.overlay-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.overlay-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.overlay-icon {
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }

--- a/src/pages/Homepage/components/MovieCard/MovieCard.style.css
+++ b/src/pages/Homepage/components/MovieCard/MovieCard.style.css
@@ -23,5 +23,6 @@
 
 .movie-card:hover {
   transform: scale(1.3) translateZ(20px);
-  z-index: 2;
+  z-index: 2; /* 다른 카드 위로 올라오도록 설정 */
+  position: relative; /* 부모와의 관계에서 z-index가 작동하도록 설정 */
 }

--- a/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.jsx
+++ b/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.jsx
@@ -4,11 +4,12 @@ import { Alert } from 'react-bootstrap';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import MovieCard from '../MovieCard/MovieCard';
+import './PopularMovieSlide.style.css';
 
 const responsive = {
   desktop: {
     breakpoint: { max: 3000, min: 1024 },
-    items: 8,
+    items: 6,
   },
   tablet: {
     breakpoint: { max: 1024, min: 464 },

--- a/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.jsx
+++ b/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.jsx
@@ -41,6 +41,7 @@ const PopularMovieSlide = () => {
         dotListClass='movie-slider p-1'
         itemClass='carousel-container'
         responsive={responsive}
+        className='carousel-container'
       >
         {data?.results.map((movie, index) => (
           <MovieCard movie={movie} key={index} />

--- a/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.style.css
+++ b/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.style.css
@@ -1,0 +1,4 @@
+.carousel-container {
+  /* overflow: hidden; */
+  height: 440px;
+}

--- a/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.style.css
+++ b/src/pages/Homepage/components/PopularMovieSlide/PopularMovieSlide.style.css
@@ -1,4 +1,5 @@
 .carousel-container {
-  /* overflow: hidden; */
+  overflow: visible; /* 자식 요소가 커질 때 잘리지 않도록 설정 */
   height: 440px;
+  position: relative; /* z-index 관리를 위해 position 속성을 추가 */
 }


### PR DESCRIPTION
## 구현한 기능
### MovieCard 구현 완료
- 관련 커밋 링크(752b6ab)
- `usePopularMoviesQuery`에서 불러온 data의 갯수만큼 MovieCard를 만들어 해당 Slide에 배치함
- icon의 경우 'react-icon'사용 (fontAwesome은 import가 잘 되지 않고, 문서 정리도 v6에서는 잘 안되어있는 것 같음)
- 카드가 상단 banner 부분에서 잘리는 문제점이 있었으나 overflow: visible, position: relative를 통해 z-index 관리를 해주어 해결함
  - tip: 개발자도구 -> 더보기 -> layer을 통해 실제 위에 위치해있는지 확인이 가능함! 
<img width="976" alt="image" src="https://github.com/user-attachments/assets/b87080c6-41da-4a7c-a432-038154e6fba9">
- MovieSlide에서 받아온 데이터를 movie로 props drilling을 통해 데이터 바인딩 완료
