### PR TITLE
Genre Id 값을 Genre Name으로 대체

### DIFF
--- a/src/common/MovieCard/MovieCard.jsx
+++ b/src/common/MovieCard/MovieCard.jsx
@@ -4,9 +4,12 @@ import './MovieCard.style.css';
 import { FaUser } from 'react-icons/fa';
 import { FaFireAlt } from 'react-icons/fa';
 import { MdNoAdultContent } from 'react-icons/md';
+import { useMovieGenreQuery } from '../../hooks/useMovieGenre';
 
 const MovieCard = ({ movie }) => {
   // console.log('moviecard', movie);
+  const { data: genreData } = useMovieGenreQuery();
+  console.log('ggg', genreData);
   return (
     <div
       style={{

--- a/src/common/MovieCard/MovieCard.jsx
+++ b/src/common/MovieCard/MovieCard.jsx
@@ -9,7 +9,17 @@ import { useMovieGenreQuery } from '../../hooks/useMovieGenre';
 const MovieCard = ({ movie }) => {
   // console.log('moviecard', movie);
   const { data: genreData } = useMovieGenreQuery();
-  console.log('ggg', genreData);
+  // console.log('ggg', genreData);
+
+  const showGenre = (genreIdList) => {
+    if (!genreData) return [];
+    const genreNameList = genreIdList.map((id) => {
+      const genreObj = genreData.find((genre) => genre.id === id);
+      return genreObj.name;
+    });
+
+    return genreNameList;
+  };
   return (
     <div
       style={{
@@ -26,7 +36,7 @@ const MovieCard = ({ movie }) => {
         </div>
         <div className='overlay-content'>
           <div className='overlay-badge'>
-            {movie.genre_ids.map((id) => (
+            {showGenre(movie.genre_ids).map((id) => (
               <Badge bg='warning'>{id}</Badge>
             ))}
           </div>

--- a/src/common/MovieCard/MovieCard.style.css
+++ b/src/common/MovieCard/MovieCard.style.css
@@ -39,6 +39,7 @@
 
 .overlay-badge {
   display: flex;
+  flex-wrap: wrap;
   gap: 5px;
 }
 

--- a/src/hooks/useMovieGenre.js
+++ b/src/hooks/useMovieGenre.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../utils/api';
+
+const fetchMovieGenre = () => {
+  return api.get(`/genre/movie/list`);
+};
+
+export const useMovieGenreQuery = () => {
+  return useQuery({
+    queryKey: ['movie-genre'],
+    queryFn: fetchMovieGenre,
+    select: (result) => result.data.genres,
+  });
+};


### PR DESCRIPTION
## 구현한 기능
## Genre Id 값 가져오기
- 관련 커밋 링크(086946d)
```jsx
const fetchMovieGenre = () => {
  return api.get(`/genre/movie/list`);
};

export const useMovieGenreQuery = () => {
  return useQuery({
    queryKey: ['movie-genre'],
    queryFn: fetchMovieGenre,
    select: (result) => result.data.genres,
  });
};
``` 
- `useMovieGenreQuery` 커스텀 훅을 만들어 활용하였음
- 슬라이드를 보여주는 것과 장르를 보여주는 것은 다르기에 새로운 훅 파일을 생성하여 분리하였음
## Genre Id 가져온 값을 Name으로 변경하기
- 관련 커밋 링크(19d4dee)
![image](https://github.com/user-attachments/assets/fc887233-9855-4d84-9a1b-8d63596265b8)
- id 숫자로만 보이는 것들을 `useMovieGenreQuery`를 이용해 받아온 데이터와 비교해 이름으로 바꿔줌
```jsx
const showGenre = (genreIdList) => {
  if (!genreData) return [];
  const genreNameList = genreIdList.map((id) => {
    const genreObj = genreData.find((genre) => genre.id === id);
    return genreObj.name;
  });

  return genreNameList;
};
``` 
## 개선할 점
### [생각한 것]
- Popular, Top Rated, upcoming의 경우 어느정도 실시간성이 유지 될 필요가 있다.
  - user의 선택이나, 조회수 등에 따라서 변경되어야 할 가능성이 있기 때문!
  - 그렇기 때문에 `staleTime`을 디폴트인 0으로 놓았음
- 하지만, '장르'의 경우라면?
  - 영화 '장르'가 갑자기 바뀌는 경우는 거의 없을 것이라고 생각함
  - 그런 이유로, 장르의 경우 `staleTime`을 10분으로 설정하고 시도하였음
### [예상]
- `staleTime`을 오래 적용하였으므로, 다른 페이지를 다녀와도 계속 해당 데이터가 'fresh'한 상태일 것이기 때문에 네트워크에 새로운 요청이 발생하지 않을 것이다
### [결과]
![image](https://github.com/user-attachments/assets/0e0d3799-d28c-4ba7-8870-41ec0a90424f)
- 예상과 다르게 계속해서 네트워크에 새로운 요청이 발생하였음
### [해결책]
- `useQuery`의 기본 동작으로 인해 컴포넌트가 다시 마운트되면 `staleTime`이 지나지 않았더라도 `queryFn`이 다시 실행될 수 있다고 한다.
- 이를 방지하기 위해 `refetchOnMount` 라는 '마운트 시 재요청 방지'옵션은 `false`로 진행해 보았다.
### [결과(해결책 적용 후)]
- 그대로 요청이 계속 발생한다... '실패'
- `react-router-dom` 라이브러리 때문인 것 같은데, 추가적으로 issue를 발행하여 공부 한 것을 정리하고, 추후 다시 리팩토링을 해볼 것
- 이 상태로 계속 네트워크 요청이 발생한다면, 쓸데없는 로딩이 발생하여 사용자 경험과, 필요없는 api 호출이 다시 발생하므로 서버 비용 등의 측면에서도 좋지 않은 결과를 초래할 것이라고 생각한다.
### [해결책 .2ver]
- 지금 staleTime을 적용해 놓더라도, '페이지 자체가 변경하는 경우'엔 해당 내용이 적용되지 않을 수 있음
- 아예 지금 쿼리 데브툴에서도 해당 캐싱 내용들 자체가 사라지는 것을 보면, 아예 없어진 것으로 보임
- 하지만, useNavigate를 사용하는 경우 적용하려던 것들이 다 그대로 적용되고, 네트워크 요청도 캐싱이 fresh된 상태로 남아있는 동안에는 그대로 유지되고 있는 것을 볼 수 있음
  - SPA 특성상 새로운 페이지를 불러오면, index.js를 통채로 다시 다운받게 되는데, 그것이 문제이지 않을까?
```
tnx to **yun&geon**
```